### PR TITLE
Add len() to IndexerCache

### DIFF
--- a/pyterrier_caching/indexer_cache.py
+++ b/pyterrier_caching/indexer_cache.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from contextlib import ExitStack
 import struct
 import pickle
+import json
 import lz4.frame
 import numpy as np
 import pandas as pd
@@ -26,6 +27,12 @@ class Lz4PickleIndexerCache(pt.Indexer):
 
     def __iter__(self) -> Iterator[Dict[str, Any]]:
         return self.get_corpus_iter()
+
+    def __len__(self) -> Optional[int]:
+        if self.built():
+            with  (Path(self.path)/'meta.json').open('rt') as fin:
+                metadata = json.load(fin)
+            return metadata['record_count']
 
     def get_corpus_iter(self, verbose: bool = False, fields: Optional[List[str]] = None, start: Optional[int] = None, stop: Optional[int] = None) -> Iterator[Dict[str, Any]]:
         # validate arguments

--- a/pyterrier_caching/indexer_cache.py
+++ b/pyterrier_caching/indexer_cache.py
@@ -29,10 +29,11 @@ class Lz4PickleIndexerCache(pt.Indexer):
         return self.get_corpus_iter()
 
     def __len__(self) -> Optional[int]:
-        if self.built():
-            with  (Path(self.path)/'meta.json').open('rt') as fin:
-                metadata = json.load(fin)
-            return metadata['record_count']
+        if not self.built():
+            raise RuntimeError('cache not built')
+        with  (Path(self.path)/'meta.json').open('rt') as fin:
+            metadata = json.load(fin)
+        return metadata['record_count']
 
     def get_corpus_iter(self, verbose: bool = False, fields: Optional[List[str]] = None, start: Optional[int] = None, stop: Optional[int] = None) -> Iterator[Dict[str, Any]]:
         # validate arguments

--- a/test/test_indexer_cache.py
+++ b/test/test_indexer_cache.py
@@ -13,6 +13,8 @@ class TestIndexerCache(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             d = Path(d)
             cache = pyterrier_caching.IndexerCache(d/'cache')
+            with self.subText('len before built'):
+                self.assertEqual(len(cache), None)
             cache.index([
                 {'docno': '1', 'data': 'test'},
                 {'docno': '2', 'data': 'caching pyterrier'},
@@ -20,6 +22,8 @@ class TestIndexerCache(unittest.TestCase):
                 {'docno': '4', 'data': 'information retrieval'},
                 {'docno': '5', 'data': 'foo bar baz'},
             ])
+            with self.subText('len when built'):
+                self.assertEqual(len(cache), 5)
             with self.subTest('full iter'):
                 self.assertEqual(list(cache), [
                     {'docno': '1', 'data': 'test'},
@@ -52,4 +56,7 @@ class TestIndexerCache(unittest.TestCase):
             d = Path(d)
             cache = pyterrier_caching.IndexerCache(d/'cache')
             cache.index(range(0))
-            self.assertEqual(list(cache), [])
+            with self.subText('len'):
+                self.assertEqual(len(cache), 0)
+            with self.subText('iter'):
+                self.assertEqual(list(cache), [])

--- a/test/test_indexer_cache.py
+++ b/test/test_indexer_cache.py
@@ -14,7 +14,8 @@ class TestIndexerCache(unittest.TestCase):
             d = Path(d)
             cache = pyterrier_caching.IndexerCache(d/'cache')
             with self.subTest('len before built'):
-                self.assertEqual(len(cache), None)
+                with self.assertRaises(RuntimeError):
+                    len(cache)
             cache.index([
                 {'docno': '1', 'data': 'test'},
                 {'docno': '2', 'data': 'caching pyterrier'},

--- a/test/test_indexer_cache.py
+++ b/test/test_indexer_cache.py
@@ -13,7 +13,7 @@ class TestIndexerCache(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             d = Path(d)
             cache = pyterrier_caching.IndexerCache(d/'cache')
-            with self.subText('len before built'):
+            with self.subTest('len before built'):
                 self.assertEqual(len(cache), None)
             cache.index([
                 {'docno': '1', 'data': 'test'},
@@ -22,7 +22,7 @@ class TestIndexerCache(unittest.TestCase):
                 {'docno': '4', 'data': 'information retrieval'},
                 {'docno': '5', 'data': 'foo bar baz'},
             ])
-            with self.subText('len when built'):
+            with self.subTest('len when built'):
                 self.assertEqual(len(cache), 5)
             with self.subTest('full iter'):
                 self.assertEqual(list(cache), [
@@ -56,7 +56,7 @@ class TestIndexerCache(unittest.TestCase):
             d = Path(d)
             cache = pyterrier_caching.IndexerCache(d/'cache')
             cache.index(range(0))
-            with self.subText('len'):
+            with self.subTest('len'):
                 self.assertEqual(len(cache), 0)
-            with self.subText('iter'):
+            with self.subTest('iter'):
                 self.assertEqual(list(cache), [])


### PR DESCRIPTION
Useful in several cases, including wrapping it in a tqdm.