### PR TITLE
Improvements to DenseScorerCache

### DIFF
--- a/pyterrier_caching/scorer_cache.py
+++ b/pyterrier_caching/scorer_cache.py
@@ -23,7 +23,6 @@ class Hdf5ScorerCache(pta.Artifact, pt.Transformer):
     def __init__(self, path, scorer=None, verbose=False):
         super().__init__(path)
         meta_file_compat(path)
-        self.mode = 'r'
         self.scorer = scorer
         self.verbose = verbose
         self.meta = None
@@ -58,7 +57,7 @@ class Hdf5ScorerCache(pta.Artifact, pt.Transformer):
         import h5py
         assert self.built(), "you must .build(...) this cache before it can be used"
         if self.file is None:
-            self.file = h5py.File(self.path/'data.h5', self.mode)
+            self.file = h5py.File(self.path/'data.h5', 'r')
         if self.meta is None:
             with (self.path/'pt_meta.json').open('rt') as fin:
                 self.meta = json.load(fin)
@@ -89,7 +88,6 @@ class Hdf5ScorerCache(pta.Artifact, pt.Transformer):
         """ Closes this cache, releasing the file pointer that it holds and writing any new results to disk. """
         if self.file is not None:
             self.dataset_cache = {} # reset the dataset cache
-            self.mode = 'r' # subsequent opens will be read only unless needed
             self.file.close()
             self.file = None
         if self.meta is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ python-terrier>=0.11.0
 pyterrier-alpha>=0.2.2
 lz4
 numpy<2.0.0
-npids
+npids>=0.0.7
 h5py
 deprecated

--- a/test/test_retriever_cache.py
+++ b/test/test_retriever_cache.py
@@ -32,11 +32,11 @@ class TestRetrieverCache(unittest.TestCase):
                 {'qid': 'a', 'query': 'a'},
                 {'qid': 'b', 'query': 'b'},
             ]))
-            self.assertTrue((res == pd.DataFrame([
+            pd.testing.assert_frame_equal(res, pd.DataFrame([
                 {'qid': 'a', 'query': 'a', 'docno': '1', 'score': 2., 'rank': 0},
                 {'qid': 'a', 'query': 'a', 'docno': '2', 'score': 1., 'rank': 1},
                 {'qid': 'b', 'query': 'b', 'docno': '2', 'score': 3., 'rank': 0},
-            ])).all().all())
+            ]))
 
             with self.subTest('make sure it doesn\'t call the retriever again on any of these'):
                 cache.retriever = retriever_raises
@@ -44,20 +44,20 @@ class TestRetrieverCache(unittest.TestCase):
                     {'qid': 'a', 'query': 'a'},
                     {'qid': 'b', 'query': 'b'},
                 ]))
-                self.assertTrue((res == pd.DataFrame([
+                pd.testing.assert_frame_equal(res, pd.DataFrame([
                     {'qid': 'a', 'query': 'a', 'docno': '1', 'score': 2., 'rank': 0},
                     {'qid': 'a', 'query': 'a', 'docno': '2', 'score': 1., 'rank': 1},
                     {'qid': 'b', 'query': 'b', 'docno': '2', 'score': 3., 'rank': 0},
-                ])).all().all())
+                ]))
 
             with self.subTest('only some of the queries'):
                 cache.retriever = retriever_raises
                 res = cache(pd.DataFrame([
                     {'qid': 'b', 'query': 'b'},
                 ]))
-                self.assertTrue((res == pd.DataFrame([
+                pd.testing.assert_frame_equal(res, pd.DataFrame([
                     {'qid': 'b', 'query': 'b', 'docno': '2', 'score': 3., 'rank': 0},
-                ])).all().all())
+                ]))
 
             with self.subTest('make sure it calls a new scorer on any unknown values'):
                 cache.retriever = pt.apply.generic(retriever_2)
@@ -65,8 +65,8 @@ class TestRetrieverCache(unittest.TestCase):
                     {'qid': 'a', 'query': 'a'},
                     {'qid': 'c', 'query': 'c'},
                 ]))
-                self.assertTrue((res == pd.DataFrame([
+                pd.testing.assert_frame_equal(res, pd.DataFrame([
                     {'qid': 'a', 'query': 'a', 'docno': '1', 'score': 2., 'rank': 0}, # old
                     {'qid': 'a', 'query': 'a', 'docno': '2', 'score': 1., 'rank': 1}, # old
                     {'qid': 'c', 'query': 'c', 'docno': '0', 'score': 0., 'rank': 0}, # new
-                ])).all().all())
+                ]))

--- a/test/test_scorer_cache.py
+++ b/test/test_scorer_cache.py
@@ -48,11 +48,11 @@ class TestDenseScorerCache(unittest.TestCase):
                 {'qid': 'a', 'query': 'a', 'docno': '2'},
                 {'qid': 'b', 'query': 'b', 'docno': '2'},
             ]))
-            self.assertTrue((res == pd.DataFrame([
+            pd.testing.assert_frame_equal(res, pd.DataFrame([
                 {'qid': 'a', 'query': 'a', 'docno': '1', 'score': 1., 'rank': 0},
                 {'qid': 'a', 'query': 'a', 'docno': '2', 'score': 1., 'rank': 1},
                 {'qid': 'b', 'query': 'b', 'docno': '2', 'score': 1., 'rank': 0},
-            ])).all().all())
+            ]))
 
             with self.subTest('make sure it doesn\'t call the scorer again on any of these'):
                 cache.scorer = scorer_raises
@@ -61,11 +61,11 @@ class TestDenseScorerCache(unittest.TestCase):
                     {'qid': 'a', 'query': 'a', 'docno': '2'},
                     {'qid': 'b', 'query': 'b', 'docno': '2'},
                 ]))
-                self.assertTrue((res == pd.DataFrame([
+                pd.testing.assert_frame_equal(res, pd.DataFrame([
                     {'qid': 'a', 'query': 'a', 'docno': '1', 'score': 1., 'rank': 0},
                     {'qid': 'a', 'query': 'a', 'docno': '2', 'score': 1., 'rank': 1},
                     {'qid': 'b', 'query': 'b', 'docno': '2', 'score': 1., 'rank': 0},
-                ])).all().all())
+                ]))
 
             with self.subTest('make sure it calls a new scorer on any unknown values'):
                 cache.scorer = scorer_2
@@ -76,13 +76,13 @@ class TestDenseScorerCache(unittest.TestCase):
                     {'qid': 'b', 'query': 'a', 'docno': '1'}, # should pull from (a,1) cache (not dependent on qid)
                     {'qid': 'c', 'query': 'c', 'docno': '1'},
                 ]))
-                self.assertTrue((res == pd.DataFrame([
+                pd.testing.assert_frame_equal(res, pd.DataFrame([
                     {'qid': 'a', 'query': 'a', 'docno': '1', 'score': 1., 'rank': 1}, # old
                     {'qid': 'a', 'query': 'a', 'docno': '3', 'score': 2., 'rank': 0}, # new
-                    {'qid': 'b', 'query': 'a', 'docno': '1', 'score': 1., 'rank': 0}, # old
-                    {'qid': 'b', 'query': 'b', 'docno': '2', 'score': 1., 'rank': 1}, # old
+                    {'qid': 'b', 'query': 'b', 'docno': '2', 'score': 1., 'rank': 0}, # old
+                    {'qid': 'b', 'query': 'a', 'docno': '1', 'score': 1., 'rank': 1}, # old
                     {'qid': 'c', 'query': 'c', 'docno': '1', 'score': 2., 'rank': 0}, # new
-                ])).all().all())
+                ]))
 
             with self.subTest('reload the cache and make sure we get the same results'):
                 cache = pyterrier_caching.DenseScorerCache(d/'cache', scorer_2)
@@ -93,13 +93,13 @@ class TestDenseScorerCache(unittest.TestCase):
                     {'qid': 'b', 'query': 'a', 'docno': '1'}, # should pull from (a,1) cache (not dependent on qid)
                     {'qid': 'c', 'query': 'c', 'docno': '1'},
                 ]))
-                self.assertTrue((res == pd.DataFrame([
+                pd.testing.assert_frame_equal(res, pd.DataFrame([
                     {'qid': 'a', 'query': 'a', 'docno': '1', 'score': 1., 'rank': 1}, # old
                     {'qid': 'a', 'query': 'a', 'docno': '3', 'score': 2., 'rank': 0}, # new
-                    {'qid': 'b', 'query': 'a', 'docno': '1', 'score': 1., 'rank': 0}, # old
-                    {'qid': 'b', 'query': 'b', 'docno': '2', 'score': 1., 'rank': 1}, # old
+                    {'qid': 'b', 'query': 'b', 'docno': '2', 'score': 1., 'rank': 0}, # old
+                    {'qid': 'b', 'query': 'a', 'docno': '1', 'score': 1., 'rank': 1}, # old
                     {'qid': 'c', 'query': 'c', 'docno': '1', 'score': 2., 'rank': 0}, # new
-                ])).all().all())
+                ]))
 
             with self.subTest('no scorer necessary if everything is already in the cache'):
                 cache = pyterrier_caching.DenseScorerCache(d/'cache')
@@ -110,13 +110,13 @@ class TestDenseScorerCache(unittest.TestCase):
                     {'qid': 'b', 'query': 'a', 'docno': '1'}, # should pull from (a,1) cache (not dependent on qid)
                     {'qid': 'c', 'query': 'c', 'docno': '1'},
                 ]))
-                self.assertTrue((res == pd.DataFrame([
+                pd.testing.assert_frame_equal(res, pd.DataFrame([
                     {'qid': 'a', 'query': 'a', 'docno': '1', 'score': 1., 'rank': 1}, # old
                     {'qid': 'a', 'query': 'a', 'docno': '3', 'score': 2., 'rank': 0}, # new
-                    {'qid': 'b', 'query': 'a', 'docno': '1', 'score': 1., 'rank': 0}, # old
-                    {'qid': 'b', 'query': 'b', 'docno': '2', 'score': 1., 'rank': 1}, # old
+                    {'qid': 'b', 'query': 'b', 'docno': '2', 'score': 1., 'rank': 0}, # old
+                    {'qid': 'b', 'query': 'a', 'docno': '1', 'score': 1., 'rank': 1}, # old
                     {'qid': 'c', 'query': 'c', 'docno': '1', 'score': 2., 'rank': 0}, # new
-                ])).all().all())
+                ]))
 
             with self.subTest('raises error if document is requested that wasn\'t in the cache and no scorer is provided'):
                 with self.assertRaises(LookupError):
@@ -160,22 +160,22 @@ class TestDenseScorerCache(unittest.TestCase):
                 res = cache.cached_retriever(num_results=2)(pd.DataFrame([
                     {'qid': 'a', 'query': 'a'},
                 ]))
-                self.assertTrue((res == pd.DataFrame([
+                pd.testing.assert_frame_equal(res, pd.DataFrame([
                     {'qid': 'a', 'query': 'a', 'docno': '5', 'score': 5., 'rank': 0},
                     {'qid': 'a', 'query': 'a', 'docno': '4', 'score': 4., 'rank': 1},
-                ])).all().all())
+                ]))
 
             with self.subTest('num_results is robust'):
                 res = cache.cached_retriever(num_results=1000)(pd.DataFrame([
                     {'qid': 'a', 'query': 'a'},
                 ]))
-                self.assertTrue((res == pd.DataFrame([
+                pd.testing.assert_frame_equal(res, pd.DataFrame([
                     {'qid': 'a', 'query': 'a', 'docno': '5', 'score': 5., 'rank': 0},
                     {'qid': 'a', 'query': 'a', 'docno': '4', 'score': 4., 'rank': 1},
                     {'qid': 'a', 'query': 'a', 'docno': '3', 'score': 3., 'rank': 2},
                     {'qid': 'a', 'query': 'a', 'docno': '2', 'score': 2., 'rank': 3},
                     {'qid': 'a', 'query': 'a', 'docno': '1', 'score': 1., 'rank': 4},
-                ])).all().all())
+                ]))
 
             with self.subTest('query b should still raise an error'):
                 with self.assertRaises(RuntimeError):


### PR DESCRIPTION
 - reading from numpy instead of hdf5
 - support for using it as a context manager
 - score_all method
 - merge_from method
 - one-phase scoring (see #5)
 - pd.testing.assert_frame_equal